### PR TITLE
 datasource: /v1/ is no longer required in AppEngine URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0-dev] - Unreleased
 ### Changed
+- Datasource automatically adds /v1/ to the Astarte AppEngine URL
 
 ## [0.11.0-rc.0] - 2020-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0-dev] - Unreleased
+### Changed
+
 ## [0.11.0-rc.0] - 2020-02-26
 
 ## [0.11.0-beta.2] - 2020-01-26

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,7 @@
 /*
    This file is part of Astarte.
 
-   Copyright 2018 Ispirata Srl
+   Copyright 2018-2020 Ispirata Srl
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ export default class AstarteDatasource {
     }
 
     baseQueryPath() {
-        return `${this.server}/${this.realm}`;
+        return `${this.server}/v1/${this.realm}`;
     }
 
     isBase64Id(deviceId) {


### PR DESCRIPTION
Users shouldn't worry about the protocol version used by astarte.
The supported version is added automatically.
Fix #9

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>