### PR TITLE
Prepare v1.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.2] - 2021-03-24
+### Changed
+- Upgrate Grafana to 7.3.10
+
 ## [1.0.0-beta.1] - 2021-02-16
 ### Changed
 - Datasource automatically adds /v1/ to the Astarte AppEngine URL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astarte-appengine-datasource",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Astarte Data Source for Grafana.",
   "scripts": {
     "build": "grafana-toolkit plugin:build",


### PR DESCRIPTION
Bump version number and add v1.0.0-beta.2 release date to CHANGELOG.md.