### PR TITLE
Add a Dockerhub build hook

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg GRAFANA_API_KEY=$GRAFANA_API_KEY -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
hooks are required for --build-arg support.