### PR TITLE
Fix dockerhub build error

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build --build-arg GRAFANA_API_KEY=$GRAFANA_API_KEY -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build --build-arg GRAFANA_API_KEY=$GRAFANA_API_KEY -f $DOCKERFILE_PATH -t $IMAGE_NAME


### PR DESCRIPTION
Fix: `"docker build" requires exactly 1 argument.`.

Signed-off-by: Davide Bettio <davide.bettio@ispirata.com>