### PR TITLE
Update node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-stretch as builder
+FROM node:16-bookworm as builder
 
 WORKDIR /app
 ADD . .

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/lodash": "latest"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "resolutions": {
     "rxjs": "6.6.3"


### PR DESCRIPTION
Node 12 is old and unsupported. Move to Node 16, contextually updating the docker builder image.